### PR TITLE
Fixed rprint formatting bug when mac address not found

### DIFF
--- a/portscanner.py
+++ b/portscanner.py
@@ -78,7 +78,7 @@ def synScan(args):
         ping = scanner.ping()
 
         if not ping:
-            rprint(f"[bold red]Host {ip} seems to be down, try again later![/bold red]")
+            rprint(f"[bold red]Host {args.ip} seems to be down, try again later![/bold red]")
             exit()
     
     


### PR DESCRIPTION
On line 80:
```
        if not ping:
            rprint(f"[bold red]Host {ip} seems to be down, try again later![/bold red]")
```
It should be:
```
        if not ping:
            rprint(f"[bold red]Host {args.ip} seems to be down, try again later![/bold red]")
```
otherwise if scanner.ping() fails, the program will crash just before exit()